### PR TITLE
Fix gulp-useref dependency

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,7 +25,7 @@
     "gulp-changed": "^0.2.1",
     "run-sequence": "^0.3.6",
     "gulp-minify-html": "^0.1.1",
-    "gulp-useref": "^0.1.2",
+    "gulp-useref": "^0.4.4",
     "gulp-csslint": "^0.1.3"
   },
   "engines": {


### PR DESCRIPTION
The useref package has been unpublished on npm.org in favor of node-useref. Bump the version of gulp-useref that has this fixed dependency, at least v 0.4.2.
