### PR TITLE
fix js watch task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -233,8 +233,8 @@ gulp.task("serve:dev", ["styles", "jekyll:dev"], function () {
 // These tasks will look for files that change while serving and will auto-regenerate or
 // reload the website accordingly. Update or add other files you need to be watched.
 gulp.task("watch", function () {
-  gulp.watch(["src/**/*.md", "src/**/*.html", "src/**/*.xml", "src/**/*.txt"], ["jekyll-rebuild"]);
-  gulp.watch(["serve/assets/stylesheets/*.css", "serve/assest/javascript/*.js"], reload);
+  gulp.watch(["src/**/*.md", "src/**/*.html", "src/**/*.xml", "src/**/*.txt", "src/**/*.js"], ["jekyll-rebuild"]);
+  gulp.watch(["serve/assets/stylesheets/*.css"], reload);
   gulp.watch(["src/assets/scss/**/*.scss"], ["styles"]);
 });
 


### PR DESCRIPTION
No changes to javascript files are being sent to the `serve` dir so nothing is updated. I have updated the watch task to rebuild jekyll on changes to js files. There is probably a better way to do this via js injection but I don't have enough time to look into it at the moment. This works good enough for now.