### PR TITLE
Add Jade support

### DIFF
--- a/app/templates/_config.yml
+++ b/app/templates/_config.yml
@@ -8,6 +8,7 @@ url: localhost:4000
 # Used so Jekyll outputs the site correctly so Gulp can do what it wants
 source: src
 destination: serve
+plugins: src/_plugins
 
 # Same as the title etc for your site but can instead be
 # called by using 'site.author.name' and so on

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -22,6 +22,7 @@
     "gulp-htmlmin": "^0.2.0",
     "gulp-if": "^1.2.4",
     "gulp-imagemin": "^2.1.0",
+    "gulp-jade": "^0.11.0",
     "gulp-jshint": "^1.8.5",
     "gulp-load-plugins": "^0.8.0",
     "gulp-minify-css": "^0.3.10",

--- a/app/templates/app/_plugins/jade.rb
+++ b/app/templates/app/_plugins/jade.rb
@@ -1,0 +1,38 @@
+##
+## This Plugin enables Jade support to pages and posts.
+##
+
+require 'open3'
+
+module Jekyll
+
+  class JadeConverter < Converter
+
+    def matches(ext)
+      ext =~ /^\.jade$/i
+    end
+
+    def output_ext(ext)
+      ".html"
+    end
+
+    def convert(content)
+      begin
+        o, e, s = Open3.capture3("jade", :stdin_data => content)
+        puts(<<-eos
+Jade Error >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+#{e}
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< Jade Error
+        eos
+        ) if e.length > 0
+      rescue Errno::ENOENT => e
+        puts "** ERROR: Jade isn't installed or could not be found."
+        puts "** ERROR: To install with NPM run: npm install jade -g"
+        return nil
+      end
+      return o
+    end
+
+  end
+
+end

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -82,6 +82,16 @@ gulp.task("copy", function () {
     .pipe($.size({ title: "xml & txt" }))
 });
 
+// Compile jade layouts into html as plugins do not have permissions
+// all other jade files are compiled directly via jade-jekyll plugin
+gulp.task('layouts', function() {
+  return gulp.src('src/_layouts/jade/*.jade')
+    .pipe($.jade({
+      pretty: true
+    }))
+    .pipe(gulp.dest('src/_layouts'));
+});
+
 // Optimizes all the CSS, HTML and concats the JS etc
 gulp.task("html", ["styles"], function () {
   var assets = $.useref.assets({searchPath: "serve"});
@@ -232,10 +242,11 @@ gulp.task("serve:dev", ["styles", "jekyll:dev"], function () {
 
 // These tasks will look for files that change while serving and will auto-regenerate or
 // reload the website accordingly. Update or add other files you need to be watched.
-gulp.task("watch", function () {
-  gulp.watch(["src/**/*.md", "src/**/*.html", "src/**/*.xml", "src/**/*.txt"], ["jekyll-rebuild"]);
-  gulp.watch(["serve/assets/stylesheets/*.css", "serve/assest/javascript/*.js"], reload);
-  gulp.watch(["src/assets/scss/**/*.scss"], ["styles"]);
+gulp.task('watch', function () {
+  gulp.watch(['src/**/*.{md,html,xml,txt,js}'], ['jekyll-rebuild']);
+  gulp.watch(['serve/assets/stylesheets/*.css'], reload);
+  gulp.watch(['src/_layouts/jade/*.jade'], ['layouts']);
+  gulp.watch(['src/assets/scss/**/*.{scss,sass}'], ['styles']);
 });
 
 // Serve the site after optimizations to see that everything looks fine

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp": "^3.8.10",
     "gulp-coveralls": "^0.1.3",
     "gulp-istanbul": "^0.5.0",
+    "gulp-jade": "^0.11.0",
     "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.0",
     "gulp-load-plugins": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "gulp": "^3.8.10",
     "gulp-coveralls": "^0.1.3",
     "gulp-istanbul": "^0.5.0",
-    "gulp-jade": "^0.11.0",
     "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.0",
     "gulp-load-plugins": "^0.8.0",


### PR DESCRIPTION
### Edit: Jade Support proposition - under review

I spent quite a **few** hours last night wrestling with Jekyll and Jade, trying to get them to work together. I have managed it with this:

Handle compilation of .jade to .html natively with plugin:
[jekyll-jade-plugin](https://github.com/snappylabs/jade-jekyll-plugin)
* note that the link to the blog post on the site is down, however I found an old cached version here: 
[Templating your Jekyll blog with Jade](https://web.archive.org/web/20130805194630/http://www.snappylabs.com/blog/web/2013/06/12/templating-your-jekyll-blog-with-jade/)
From the Blog:

 > Unfortunately Jekyll currently ignores the converter plugin for any .jade files in the _layouts/ folder.

> The future-proof workaround I instead recommend is to render Jade layouts outside of Jekyll and have it later pick them up as HTML files. Fortunately this use-case is an infrequent one in the steady-state and very easy to manage nevertheless:

> Separate your Jade layout files into a new _layouts/jade/ folder for convenience
> ~~In one terminal, run a Jade watched render: jade -w -o ../ *.jade~~
> ~~In another terminal, run the Jekyll build: jekyll serve -w~~

Don't worry about the above as gulp-jade will handle layouts
gulp-jade to handle _layouts
[gulp-jade](https://www.npmjs.com/package/gulp-jade)

> Now when you update your layouts, Jade will generate a HTML-version (step 2) that will be picked up by Jekyll automatically (step 3).

Unfortunately I am unfamiliar with Yeoman generators. I think it would be best if Jade were added as an option during generation, but I don't have much time to do that at the moment. This way it will just work if you start using .jade files.

### Regarding layouts:
https://github.com/jadejs/jade/issues/1401
_Use jade's verbatim otherwise there will be a skipped line before the yml front-matter and jekyll will ignore the file_
```
  :verbatim
    ---
    layout: my layout
    ---
```