### PR TITLE
Update gulpfile.js

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -234,7 +234,6 @@ gulp.task("serve:dev", ["styles", "jekyll:dev"], function () {
 // reload the website accordingly. Update or add other files you need to be watched.
 gulp.task("watch", function () {
   gulp.watch(["src/**/*.md", "src/**/*.html", "src/**/*.xml", "src/**/*.txt", "src/**/*.js"], ["jekyll-rebuild"]);
-  gulp.watch(["serve/assets/stylesheets/*.css"], reload);
   gulp.watch(["src/assets/scss/**/*.scss"], ["styles"]);
 });
 


### PR DESCRIPTION
Removing the gulp.watch line for the compiled css file, since it's causing a full browser reload after we already injected the css changes.
Or am I missing something? Seems to work for me at least... 
Awesome yeoman gen in general by the way!