### PR TITLE
added autowiring of bower dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,12 @@ repositories there are some things you need to do:
 
 ### Bower
 
-**Currently not implemented**
+Bower dependencies are injected into the 2 jekyll includes ``bower_scripts.html`` and ``bower_styles.html``. So install a bower dependency and yet you have it autowired in your jekyll site.
+
+You can define ``bowerExcludes`` in the gulpfile. 
+
+**TODO**
+- SCSS currently not supported
 
 ## Roadmap
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -35,7 +35,8 @@
     "gulp-uncss": "^0.5.0",
     "gulp-useref": "^1.0.2",
     "jshint-stylish": "^1.0.0",
-    "merge-stream": "^0.1.6"
+    "merge-stream": "^0.1.6",
+    "wiredep": "^2.2.2"
   },
   "engines": {
     "node": ">0.10.0"

--- a/app/templates/app/_includes/bower_scripts.html
+++ b/app/templates/app/_includes/bower_scripts.html
@@ -1,0 +1,2 @@
+<!-- bower:js -->
+<!-- endbower -->

--- a/app/templates/app/_includes/bower_styles.html
+++ b/app/templates/app/_includes/bower_styles.html
@@ -1,0 +1,2 @@
+<!-- bower:css -->
+<!-- endbower -->

--- a/app/templates/app/_includes/head.html
+++ b/app/templates/app/_includes/head.html
@@ -15,14 +15,16 @@
 
   <!-- CSS -->
   <!-- build:css /assets/stylesheets/style.min.css -->
+  {% include bower_styles.html %}
   <link rel="stylesheet" href="/assets/stylesheets/style.css">
   <!-- endbuild -->
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
 
   <!-- JS -->
   <!-- build:js /assets/javascript/all.min.js -->
-  <script src="/assets/javascript/javascript.js"></script> 
-  <script src="/assets/javascript/somejavascript.js"></script> 
+  {% include bower_scripts.html %}
+  <script src="/assets/javascript/javascript.js"></script>
+  <script src="/assets/javascript/somejavascript.js"></script>
   <!-- endbuild -->
 
   <!-- Icons -->

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -59,7 +59,7 @@ test/
 *.sublime-workspace
 *.sublime-projectcompletions
 
-app/_bower_components
+src/_bower_components
 
 # Output folders
 serve

--- a/test/test-gulp.js
+++ b/test/test-gulp.js
@@ -58,20 +58,28 @@ describe("Jekyllized generator test for Gulp tasks without any uploading", funct
     tasks.assertTaskExists(this.jekyllized, "clean:prod", [], done);
   });
 
-  it("should contain jekyll:dev task", function (done) {
-    tasks.assertTaskExists(this.jekyllized, "jekyll:dev", [], done);
+  it("should contain jekyll:pure task", function (done) {
+    tasks.assertTaskExists(this.jekyllized, "jekyll:pure", [], done);
   });
 
-  it("should contain jekyll-rebuild task with jekyll:dev included", function (done) {
-    tasks.assertTaskExists(this.jekyllized, "jekyll-rebuild", ["jekyll:dev"], done);
+  it("should contain jekyll:dev task with bower included", function (done) {
+    tasks.assertTaskExists(this.jekyllized, "jekyll:dev", ["bower"], done);
   });
 
-  it("should contain jekyll:prod task", function (done) {
-    tasks.assertTaskExists(this.jekyllized, "jekyll:prod", [], done);
+  it("should contain jekyll-rebuild task with jekyll:pure included", function (done) {
+    tasks.assertTaskExists(this.jekyllized, "jekyll-rebuild", ["jekyll:pure"], done);
+  });
+
+  it("should contain jekyll:prod task with bower included", function (done) {
+    tasks.assertTaskExists(this.jekyllized, "jekyll:prod", ["bower"], done);
   });
 
   it("should contain styles task", function (done) {
     tasks.assertTaskExists(this.jekyllized, "styles", [], done);
+  });
+
+  it("should contain bower task with bower:files included", function (done) {
+    tasks.assertTaskExists(this.jekyllized, "bower", ["bower:files"], done);
   });
 
   it("should contain images task", function (done) {


### PR DESCRIPTION
By using [wiredep](https://github.com/taptapship/wiredep) on 2 jekyll includes:

Bower dependencies are injected into the 2 jekyll includes ``bower_scripts.html`` and ``bower_styles.html``. So install a bower dependency and yet you have it autowired into your jekyll site.

You can define ``bowerExcludes`` in the gulpfile.

