### PR TITLE
Small Syntax error in Gulp File

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -36,7 +36,7 @@ gulp.task("jekyll-rebuild", ["jekyll:dev"], function () {
 // Almost identical to the above task, but instead we load in the build configuration
 // that overwrites some of the settings in the regular configuration so that you
 // don"t end up publishing your drafts or future posts
-gulp.task("jekyll:prod", $.shell.task("jekyll build --config _config.yml,_config.build.yml"));
+gulp.task("jekyll:prod", $.shell.task("jekyll build --config _config.yml, _config.build.yml"));
 
 // Compiles the SASS files and moves them into the "assets/stylesheets" directory
 gulp.task("styles", function () {


### PR DESCRIPTION
Found a small syntax error during production. Thank you for the generator! Learned a lot about jekyll from it.

```
gulp.task("jekyll:prod", $.shell.task("jekyll build --config _config.yml,_config.build.yml"));
```
changed to :

```
gulp.task("jekyll:prod", $.shell.task("jekyll build --config _config.yml, _config.build.yml"));
```