### PR TITLE
changing to us-east-1

### DIFF
--- a/app/templates/conditionals/_aws-credentials.json
+++ b/app/templates/conditionals/_aws-credentials.json
@@ -2,6 +2,6 @@
     "key": "<%= amazonKey %>",
     "secret": "<%= amazonSecret %>",
     "bucket": "<%= amazonBucket %>",
-    "region": "us-west-1",
+    "region": "us-east-1",
     "distributionId": "<%= amazonDistID %>"
 }


### PR DESCRIPTION
AWS uses us-east-1 as the default. Without this, a user will need to manually change before `gulp deploy` or else run into error.

```
gulp deploy
[15:20:33] Using gulpfile ~/www.fungibleclouds.com/gulpfile.js
[15:20:33] Starting 'deploy'...
[15:20:33] Finished 'deploy' after 265 ms

events.js:141
      throw er; // Unhandled 'error' event
            ^
Error: HTTP 301 Response returned from S3
```