### PR TITLE
Add missing dependency: gulp-newer

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -42,6 +42,7 @@ module.exports = generators.Base.extend({
         'gulp-inject': '^2.2.0',
         'gulp-load-plugins': '^1.0.0-rc.1',
         'gulp-minify-css': '^1.2.0',
+        'gulp-newer': '^1.0.0',
         'gulp-postcss': '^6.0.0',
         'gulp-rename': '^1.2.2',
         'gulp-rev': '^6.0.0',

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -43,6 +43,7 @@ describe('jekyllized:gulp', function () {
         '"gulp-inject": "^2.2.0"',
         '"gulp-load-plugins": "^1.0.0-rc.1"',
         '"gulp-minify-css": "^1.2.0"',
+        '"gulp-newer": "^1.0.0"',
         '"gulp-postcss": "^6.0.0"',
         '"gulp-rename": "^1.2.2"',
         '"gulp-rev": "^6.0.0"',


### PR DESCRIPTION
This appeared to be missing from the dependencies list:

```
TypeError: $.newer is not a function
    at /Users/davidcalhoun/Sites/static/gn-marketing/gulpfile.babel.js:82:13
    at bound (domain.js:280:14)
    at runBound (domain.js:293:12)
    at asyncRunner (/Users/davidcalhoun/Sites/static/gn-marketing/node_modules/async-done/index.js:36:18)
    at doNTCallback0 (node.js:417:9)
    at process._tickDomainCallback (node.js:387:13)
```