### PR TITLE
Remove unused dependency: gulp-changed

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -32,7 +32,6 @@ module.exports = generators.Base.extend({
         'eslint-config-xo-space': '^0.5.0',
         'gulp': 'git://github.com/gulpjs/gulp.git#4.0',
         'gulp-cache': '~0.3.0',
-        'gulp-changed': '^1.0.0',
         'gulp-concat': '^2.6.0',
         'gulp-eslint': '^1.0.0',
         'gulp-gzip': '^1.1.0',

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -33,7 +33,6 @@ describe('jekyllized:gulp', function () {
         '"eslint-config-xo-space": "^0.5.0"',
         '"gulp": "git://github.com/gulpjs/gulp.git#4.0"',
         '"gulp-cache": "~0.3.0"',
-        '"gulp-changed": "^1.0.0"',
         '"gulp-concat": "^2.6.0"',
         '"gulp-eslint": "^1.0.0"',
         '"gulp-gzip": "^1.1.0"',


### PR DESCRIPTION
This appeared to be unused — possibly related to #101 and the use of gulp-newer.