### PR TITLE
Fix CSS Reloading

### DIFF
--- a/generators/gulp/templates/gulpfile.babel.js
+++ b/generators/gulp/templates/gulpfile.babel.js
@@ -97,7 +97,7 @@ gulp.task('styles', () =>
       showFiles: true
     })))
     .pipe(gulp.dest('.tmp/assets/stylesheets'))
-    .pipe($.if(!argv.prod, browserSync.stream()))
+    .pipe($.if(!argv.prod, browserSync.stream({match: '**/*.css'})))
 );
 
 // 'gulp scripts' -- creates a index.js file from your JavaScript files and


### PR DESCRIPTION
Based off of #111, the CSS files are not reloading without the added !important. The reason was because browser-sync was detecting the added .map files, and triggering a full reload instead of a inject. 

See [here](https://www.browsersync.io/docs/gulp/#gulp-sass-maps) for more information. 

