### PR TITLE
Fix sondr3/generator-jekyllized#126

### DIFF
--- a/generators/jekyll/templates/config.yml
+++ b/generators/jekyll/templates/config.yml
@@ -67,4 +67,4 @@ jekyll-archives:
     year: '/archive/:year/'
     month: '/archive/:year/:month/'
     category: '/category/:name/'
-    tags: '/tag/:name/'
+    tag: '/tag/:name/'


### PR DESCRIPTION
The permalink directive for tags in jekyll-archives module configuration
should be permalink.tag, not permalink.tags

Fixes #126